### PR TITLE
AddSettings

### DIFF
--- a/DeepLinkPractice1/Managers/DeepLinkManager.swift
+++ b/DeepLinkPractice1/Managers/DeepLinkManager.swift
@@ -60,3 +60,4 @@ class DeepLinkManager: ObservableObject {
     //MVVM을 준수하기 위하여 updateNavigationPath를 만들어 적용했다.
     //NavigationPath을 비우기 위해 일반적으로도 initialize를 하는지 다른 방법이 있는지 궁금함.
 }
+    


### PR DESCRIPTION
deeplink를 사용하기 위해서는 urltype을 설정합니다. id와 schemes를 설정해 줘야합니다.
<img src = "https://github.com/SunKangYMCA/DeepLinkPractice1/assets/131300865/067d6161-0b2f-45d4-af24-e37b7b524783" width="500">

manager에 update를 추가하여 detailView를 navigationPath를 이용해 deeplink합니다. 의문 사항도 발생합니다.
<img src = "https://github.com/SunKangYMCA/DeepLinkPractice1/assets/131300865/4ac3eb78-e30d-4473-a06f-e1dd1e037284" width="500">

onAppear와 onChange를 사용합니다.
<img src = "https://github.com/SunKangYMCA/DeepLinkPractice1/assets/131300865/7497f109-d163-42cb-a03d-bdfae731ddba" width="500">

deeplink를 실행하기위해 onOpenURL을 적용합니다.
<img src = "https://github.com/SunKangYMCA/DeepLinkPractice1/assets/131300865/3ed16cf9-fa24-462d-abef-cea05f3dd811" width="500">

수정하면서 기존에 궁금했던 사항이 풀립니다. 왜 옵셔널 스트링을 줬었는지.
<img src = "https://github.com/SunKangYMCA/DeepLinkPractice1/assets/131300865/42a46fa4-ed36-4cb3-b02f-ec77fc36aa50" width="500">




